### PR TITLE
connection to cloud working for production

### DIFF
--- a/config/db.config.js
+++ b/config/db.config.js
@@ -1,23 +1,29 @@
 const mongoose = require("mongoose");
-const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/ironvegan';
+MONGODB_URI =
+  process.env.NODE_ENV === "development"
+    ? "mongodb://127.0.0.1:27017/ironvegan"
+    : process.env.MONGODB_URI;
 
 // mongoose connect
 mongoose
   .connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true })
-  .then(() => console.info(`Successfully connected to the database ${MONGODB_URI}`))
+  .then(() =>
+    console.info(`Successfully connected to the database ${MONGODB_URI}`)
+  )
   .catch((error) => {
-    console.error(`An error ocurred trying to connect to de database ${MONGODB_URI}`, error);
+    console.error(
+      `An error ocurred trying to connect to de database ${MONGODB_URI}`,
+      error
+    );
     process.exit(0);
   });
 
 // close connection
-process.on('SIGINT', function () {
+process.on("SIGINT", function () {
   mongoose.connection.close(function () {
-    console.log('Mongoose disconnected on app termination');
+    console.log("Mongoose disconnected on app termination");
     process.exit(0);
   });
 });
 
 module.exports.DB = MONGODB_URI;
-
-

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "seeds": "node ./bin/seeds.js",
-    "start": "node app.js",
-    "dev": "nodemon -e hbs,js,css app.js"
+    "start": "NODE_ENV=production node app.js",
+    "dev": "NODE_ENV=development nodemon -e hbs,js,css app.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**.env File updated in Trello.**

Cuando usamos `npm run dev` la pagina web conectará a MongoCompass (local)
Cuando subimos la pagina web `npm start` es el defecto, y la pagina web conectará a MongoAtlas (nube) con 241 restaurantes
![Screenshot 2022-03-05 at 13 36 21](https://user-images.githubusercontent.com/58273749/156883886-f79e3b3b-cdca-4ea6-825d-eeda7b0103c2.png)
![Screenshot 2022-03-05 at 13 36 39](https://user-images.githubusercontent.com/58273749/156883888-fa5f44bd-7e54-4462-bfe7-6ff3a1b1ba34.png)
